### PR TITLE
Replace PyPDF2 with pypdf 5.2.0

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ from werkzeug.utils import secure_filename
 from werkzeug.middleware.proxy_fix import ProxyFix
 import ebooklib
 from ebooklib import epub
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 import openai
 from dotenv import load_dotenv
 from functools import wraps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flask>=3.1.0
 ebooklib>=0.18
-PyPDF2>=3.0.2  # Fixed CVE-2023-36464
+pypdf==5.2.0
 openai>=1.60.2
 python-dotenv>=1.0.1
 


### PR DESCRIPTION
This PR replaces PyPDF2 with pypdf 5.2.0 to address package issues. Changes made:

- Updated requirements.txt to use pypdf==5.2.0
- Updated import statement in app.py to use pypdf instead of PyPDF2

The code functionality remains the same as pypdf maintains API compatibility with the PdfReader methods we use.