### PR TITLE
fix: enable CORS and adjust security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 from typing import List, Dict, Optional
 from flask import Flask, request, render_template, jsonify, abort
+from flask_cors import CORS
 from werkzeug.utils import secure_filename
 from werkzeug.middleware.proxy_fix import ProxyFix
 import ebooklib
@@ -28,6 +29,7 @@ if not OPENAI_API_KEY:
 
 # Initialize Flask app with security headers
 app = Flask(__name__)
+CORS(app, resources={r"/*": {"origins": "*"}})  # Allow all origins for testing
 app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 
 # Security configurations
@@ -67,7 +69,10 @@ def add_security_headers(response):
     response.headers['X-Frame-Options'] = 'SAMEORIGIN'
     response.headers['X-XSS-Protection'] = '1; mode=block'
     response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
-    response.headers['Content-Security-Policy'] = "default-src 'self'"
+    response.headers['Content-Security-Policy'] = "default-src * 'unsafe-inline' 'unsafe-eval'; img-src * data:"
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    response.headers['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS'
+    response.headers['Access-Control-Allow-Headers'] = 'Content-Type'
     return response
 
 def extract_chapters_epub(file_path: str) -> List[Dict[str, str]]:


### PR DESCRIPTION
## Changes

This PR enables CORS and adjusts security headers to allow external access:

### CORS Support

1. **CORS Configuration**:
   - Added `flask-cors` package
   - Configured CORS to allow all origins for testing
   - Added explicit CORS headers for all requests

2. **Security Headers**:
   - Adjusted Content-Security-Policy to allow external resources
   - Added CORS-specific headers:
     * Access-Control-Allow-Origin: *
     * Access-Control-Allow-Methods: GET, POST, OPTIONS
     * Access-Control-Allow-Headers: Content-Type

### Dependencies

Added new dependency:
- `flask-cors` for CORS support

### Testing

To test the changes:
```bash
ALLOW_ALL_INTERFACES=true python app.py
```

The server should now:
1. Accept requests from any origin
2. Allow necessary HTTP methods
3. Support external resource loading

### Security Note

These changes intentionally relax some security restrictions to allow external access. In a production environment, you should:
1. Restrict CORS origins to specific domains
2. Tighten Content-Security-Policy as needed
3. Consider additional security measures