### PR TITLE
fix: increase maximum file upload size to 50MB

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 
 # Security configurations
 app.config['UPLOAD_FOLDER'] = os.path.abspath(os.path.join(os.path.dirname(__file__), 'uploads'))
-app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  # 16MB max file size
+app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024  # 50MB max file size
 app.config['ALLOWED_EXTENSIONS'] = {'epub', 'pdf'}
 app.config['RATE_LIMIT'] = {'requests': 100, 'window': 3600}  # 100 requests per hour
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,7 @@ upstream web {
 
 server {
     listen 80;
+    client_max_body_size 50M;  # Allow request bodies up to 50MB
 
     location / {
         proxy_pass http://web;


### PR DESCRIPTION
- Update Flask app configuration to allow 50MB file uploads
- Configure Nginx to support 50MB request body size
- Modify MAX_CONTENT_LENGTH setting in app.py
- Add client_max_body_size directive in nginx.conf